### PR TITLE
Math TeX support v0.1

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,6 +4,7 @@
 {{- partial "head/googleplus.html" . }}
 {{- partial "head/facebook.html" . }}
 {{- partial "head/verify.html" . }}
+{{- partial "head/math.html" . }}
 {{- partialCached "head/style.html" . }}
 {{- partial "head/config.html" . }}
 {{- partialCached "head/analytics.html" . }}

--- a/layouts/partials/head/math.html
+++ b/layouts/partials/head/math.html
@@ -1,0 +1,32 @@
+{{- with .Site.Params.math.mathjax.enable }}
+<script>
+  window.MathJax = {
+    tex: {
+      inlineMath: [["$", "$"]],
+    }
+  };
+</script>
+<script type="text/javascript" id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+</script>
+{{- end }}
+{{- with .Site.Params.math.katex.enable }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css" integrity="sha384-Xi8rHCmBmhbuyyhbI88391ZKP2dmfnOl4rT9ZfRI7mLTdk1wblIUnrIq35nqwEvC" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.js" integrity="sha384-X/XCfMm41VSsqRNQgDerQczD69XqmjOOOwYQvr/uuC+j4OPoNhVgjdGFwhvN02Ja" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/contrib/auto-render.min.js" integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, {
+          // customised options
+          // auto-render specific keys, e.g.:
+          delimiters: [
+              {left: '$$', right: '$$', display: true},
+              {left: '$', right: '$', display: false},
+              {left: '\\(', right: '\\)', display: false},
+              {left: '\\[', right: '\\]', display: true}
+          ],
+          // rendering keys, e.g.:
+          throwOnError : false
+        });
+    });
+</script>
+{{- end }}


### PR DESCRIPTION
Resolved: #27 支持数据公式渲染支持

Simple math support by mathjax/katex (both display and inline)

Refer to:
https://note.qidong.name/2018/03/hugo-mathjax/
https://adityatelange.github.io/hugo-PaperMod/posts/math-typesetting/
https://katex.org/docs/autorender.html

Known issues:
* Systematic math js management
* Load math js when necessary, not on every page