### PR TITLE
fix bug  404 of uppercase tag or category name

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -24,7 +24,7 @@
         <ul class="category-list">
           {{- range $name, $items := $cats }}
           <li class="category-list-item">
-            <a class="category-list-link" href="{{ "/categories/" | relLangURL }}{{ $name | urlize | lower  }}" data-pjax-state="">{{ .Page.Title }}</a>
+            <a class="category-list-link" href="{{ "/categories/" | relLangURL }}{{ $name | urlize  }}" data-pjax-state="">{{ .Page.Title }}</a>
             <span class="category-list-count">{{ len $items }}</span>
           </li>
           {{- end }}
@@ -41,7 +41,7 @@
       <div class="tag-cloud-tags">
         {{ $randNums := (seq 10) }}
         {{- range $name, $items := $tags }}
-        <a class="tag-cloud-{{ index (shuffle $randNums) 0 }}" href="{{ "/tags/" | relLangURL }}{{ $name | urlize | lower  }}">{{ .Page.Title }}
+        <a class="tag-cloud-{{ index (shuffle $randNums) 0 }}" href="{{ "/tags/" | relLangURL }}{{ $name | urlize  }}">{{ .Page.Title }}
           <span class="tag-list-count">
             <sup>({{ len $items }})</sup>
           </span>


### PR DESCRIPTION
fix bug of 404 when the tag or category  name is uppercase

Signed-off-by: ḕℏỈẍȓ <ehlxr.me@gmail.com>