### PR TITLE
Fix typing lag in search bar by lazy-loading

### DIFF
--- a/assets/js/3rd/search/local.js
+++ b/assets/js/3rd/search/local.js
@@ -271,7 +271,46 @@ NexT.plugins.search.localsearch = function() {
       container.classList.remove('no-result');
       container.innerHTML = `<div class="search-stats">${stats}</div>
         <hr>
-        <ul class="search-result-list">${resultItems.map(result => result.item).join('')}</ul>`;
+        <ul class="search-result-list"></ul>`;
+      (function () {
+        const ul = container.querySelector('.search-result-list');
+        const itemLimit = 1;
+        const subitemLimit = 20;
+        const appendItem = () => {
+          let count = 0;
+          for (const result of resultItems.splice(0, itemLimit)) {
+            const div = document.createElement('div');
+            div.innerHTML = result.item;
+            const li = div.firstElementChild;
+            // Should the title be considered a subitem? Perhaps it should.
+            // count += Math.max(1, li.childElementCount - 1);
+            count += li.childElementCount;
+            ul.append(li);
+          };
+          return count;
+        };
+        // Count subitems instead of items.
+        const appendItems = () => {
+          let count = 0;
+          while (count < subitemLimit && resultItems.length > 0) {
+            const incr = appendItem();
+            if (!incr) {
+              console.log('local.js: cannot push items to the result list.')
+              break;
+            }
+            count += incr;
+          }
+        };
+        appendItems();
+        // Use onscroll instead of addEventListener('scroll', ...),
+        // and let the new event handler replace the old one.
+        container.onscroll = () => {
+          const scrollBottom = container.scrollTop + container.clientHeight;
+          if (container.scrollHeight - scrollBottom < 50) {
+            appendItems();
+          }
+        };
+      })();
       if (typeof pjax === 'object') pjax.refresh(container);
     }
   };


### PR DESCRIPTION
# 搜索栏输入延迟

搜索结果很多时，一次性向列表中添加大量的列表项会导致界面短暂卡住，用户输入字符的上屏会有延迟。列表懒加载可以减少一次性添加的列表项数目，从而消除延迟。

以[此仓库](https://github.com/hxhue/hugo-theme-next-pull-161)的内容为例（将其直接作为 hugo 工程的 content 目录），在本地搜索功能中键入字符 `a`，a 并没有马上上屏。清空搜索栏，重新输入任何常见的英文单词，每个字母的键入也有不同程度的延迟现象。下面是和上面提供的测试内容对应的 config.yaml 配置项：

```yaml
params:
  mainSections:
    - "posts"
    - "cpp-templates-the-complete-guide"
    - "cuda-by-example"
    - "pro-git-the-book"
    - "modern-cmake-for-cpp"
    - "inside-the-cpp-object-model"
    - "the-linux-programming-interface"
    - "cpp-concurrency-in-action"
```