### PR TITLE
在页脚中添加网安备案号的条件显示

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -28,8 +28,10 @@
 {{ if .enable }}
 <div class="beian">
   <a href="https://beian.miit.gov.cn" target="_blank">{{ .icp }}</a>
+  {{ if .gonganNum }}
   <img src="/imgs/gongan.png" alt="{{ .provinceAbbr }}公网安备">
   <a href="http://www.beian.gov.cn/portal/registerSystemInfo?recordcode={{ .gonganNum }}" target="_blank">{{ .provinceAbbr }}公网安备 {{ .gonganNum }} 号</a>
+  {{ end }}
 </div>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
有的网站并没有网安备案号，在为空的情况下，不显示网安备案号，而不是显示`公网安备 号`。