### PR TITLE
example site: fix error when previewing with latest hugo version 0.147.4

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -10,6 +10,6 @@
   {{ partial "post.html"  (dict "ctx" . "IsHome" true) }}
 {{ end }}
 
-{{ partial "partials/pagination.html" . }} 
+{{ partial "pagination.html" . }} 
  
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,5 +7,5 @@
   {{ partial "post.html"  (dict "ctx" . "IsHome" true) }}
 {{ end }}
 
-{{ partial "partials/pagination.html" . }}  
+{{ partial "pagination.html" . }}  
 {{ end }}


### PR DESCRIPTION
When previewing example site with latest hugo version 0.147.4, an error is thrown:

```
WARN  Partial name "partials/pagination.html" starting with 'partials/'
(as in {{ partial "partials/pagination.html"}}) is most likely not what you want.
Before 0.146.0 we did a double lookup in this situation.
You can suppress this warning by adding the following to your site configuration:
ignoreLogs = ['warning-partial-superfluous-prefix']
ERROR render of "/" failed: "/home/andreas/hugo-theme-next/layouts/index.html:10:3":
execute of template failed: template: index.html:10:3: executing "main"
at <partial "partials/pagination.html" .>: error calling partial: partial "partials/pagination.html" not found
```

This PR fixes that error.