### PR TITLE
Add canonical tag for SEO optimisation

### DIFF
--- a/layouts/_partials/head/meta.html
+++ b/layouts/_partials/head/meta.html
@@ -29,3 +29,10 @@
 {{ .Scratch.Set "metaImg" $img }}
 <meta itemprop="image" content="{{ $img | absURL }}" />
 <meta itemprop="keywords" content="{{ if and .IsPage (isset .Params "tags")}}{{ delimit .Params.tags "," }}{{ else }}{{ .Site.Params.keywords }}{{ end }}" />
+{{- $canonical := "" -}}
+{{- if and .IsNode .Paginator -}}
+  {{- $canonical = .Paginator.URL | absURL -}}
+{{- else -}}
+  {{- $canonical = .Permalink -}}
+{{- end }}
+<link rel="canonical" href="{{ $canonical | safeURL }}" />


### PR DESCRIPTION
`canonical` tag will fix the problem below:

<img width="1227" alt="image" src="https://github.com/user-attachments/assets/c79bdfcd-4e08-4542-820b-b709258699c3" />
