### PR TITLE
add Umami analytics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,28 @@ tags:
 # Support Math Formulas render, options: mathjax, katex
 #math: mathjax
 ---
+
+## 📊 Analytics Integration
+
+Hugo NexT theme supports multiple analytics services to track website traffic and user behavior. 
+
+Currently supported analytics services:
+- 51La Analytics
+- Baidu Analytics
+- Google Analytics
+- Cloudflare Analytics
+- Busuanzi Count
+- **Umami Analytics** (newly added)
+
+To enable Umami Analytics, add the following configuration to your `hugo.yaml`:
+
+```yaml
+params:
+  analytics:
+    umami:
+      enable: true
+      websiteId: '<your-umami-website-id>'
+      scriptUrl: 'https://<your-umami-domain>/script.js'
 ```
 
 ## 🎉 User's Cases

--- a/README.zh.md
+++ b/README.zh.md
@@ -168,6 +168,30 @@ tags:
 # 开启数学公式渲染，可选值： mathjax, katex
 #math: mathjax
 ---
+
+## 📊 统计分析集成
+
+Hugo NexT 主题支持多种分析服务，用于跟踪网站流量和用户行为。
+
+目前支持的分析服务包括：
+- 51La 统计
+- 百度统计
+- Google Analytics
+- Cloudflare Analytics
+- Busuanzi Count
+- **Umami Analytics** (新增)
+
+要启用 Umami Analytics，请在您的 `hugo.yaml` 中添加以下配置：
+
+```yaml
+params:
+  analytics:
+    umami:
+      enable: true
+      websiteId: '<your-umami-website-id>'
+      scriptUrl: 'https://<your-umami-domain>/script.js'
+```
+
 ```
 
 ## 🎉 用户案例

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -524,7 +524,7 @@ params:
       icp: 粤ICP备 18047355-1 号
       # 公安网备的省份简称
       provinceAbbr: 沪
-      # 公安网备案号
+      # 公安网备号
       gonganNum: 31011402009770
 
     # 站点支持供应商列表
@@ -1122,6 +1122,13 @@ params:
     busuanzi:
       visitorsIcon: fa fa-user
       viewsIcon: fa fa-eye
+    # Umami 统计
+    # Umami Analytics
+    # More information: https://umami.is/
+    umami:
+      enable: false
+      websiteId: '<your-umami-website-id>'
+      scriptUrl: 'https://<your-umami-domain>/script.js'
 
   # ---------------------------------------------------------------
   # 内容搜索服务

--- a/layouts/_partials/_thirdparty/analytics/umami.html
+++ b/layouts/_partials/_thirdparty/analytics/umami.html
@@ -1,0 +1,3 @@
+{{- if .Site.Params.analytics.umami.enable -}}
+<script async defer data-website-id="{{ .Site.Params.analytics.umami.websiteId }}" src="{{ .Site.Params.analytics.umami.scriptUrl }}"></script>
+{{- end -}}

--- a/layouts/_partials/head/script/analytics.html
+++ b/layouts/_partials/head/script/analytics.html
@@ -13,3 +13,6 @@
 {{ if isset .Site.Params.analytics "cloudflare" }}
   {{ partial "_thirdparty/analytics/cloudflare.html" . }}  
 {{ end }}
+{{ if isset .Site.Params.analytics "umami" }}
+  {{ partial "_thirdparty/analytics/umami.html" . }}  
+{{ end }}


### PR DESCRIPTION
添加umami支持，测试通过使用hugo-theme-next/exampleSite/startup.sh测试可以生效